### PR TITLE
fix Custom Resource & S3 bucket name

### DIFF
--- a/01-appCore/initDB/initMenu.js
+++ b/01-appCore/initDB/initMenu.js
@@ -23,17 +23,15 @@ const params = {
   }
 }
 
-// Load in d template
-initMenuState.map((d) => {
-  console.log(d)
+// Load the template
+  console.log(JSON.stringify(initMenuState));
   params.RequestItems[configTableName].push ({
     PutRequest: {
       Item: {
-        ...d
+        ...initMenuState
       }
     }
   })
-})
 
 initCountingState.map((d) => {
   console.log(d)

--- a/01-appCore/template.yaml
+++ b/01-appCore/template.yaml
@@ -60,7 +60,7 @@ Resources:
   JourneyBucket:
     Type: AWS::S3::Bucket
     Properties: 
-      BucketName: !Sub serverlesspresso-order-journey-journeybucket-${AWS::Region}
+      BucketName: !Sub serverlesspresso-order-journey-${AWS::Region}-${AWS::AccountId}
 
 
   OrderJourneyService:


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!

1 - Custom Resource is failing following this commit https://github.com/aws-samples/serverless-coffee/commit/52f5ec63de1f5fc805f4dbaecd64f8f48d003952

2 - S3 bucket was not unique

## Description
- Fix the code that loads the data to be inserted into DynamoDB, one element instead of an array
- Add accountID in bucket name to make it unique
- 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Impossible to deploy  the micro services stack: the custom resource was failing.
After the fix on the CR, impossible to deploy the stack as the S3 bucket name existed already

## How Has This Been Tested?
I was able to deploy the micro services stack.

## Screenshots (if appropriate):
