### PR TITLE
Make paths relative, not absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This create a custom event bus, custom SMS auth flow for Cognito signin, and oth
 
 1. From the command line, install the realtime messaging stack:
 ```
-cd /00-baseCore
+cd 00-baseCore
 sam build
 sam deploy --guided
 ```
@@ -37,7 +37,7 @@ During the prompts, enter `serverlesspresso-core` for the Stack Name, `core` for
 ### 2. Install microservices
 
 ```
-cd /01-appCore
+cd 01-appCore
 sam build
 sam deploy --guided
 ```


### PR DESCRIPTION
Fix the `cd: no such file or directory: /00-baseCore` error when following steps in the README:

```
cd /00-baseCore
sam build
sam deploy --guided
cd: no such file or directory: /00-baseCore
```

## Description
The absolute paths in the README don't work, switch to use relative paths so you can copy/paste.

## Related Issue
[Issue 16](https://github.com/aws-samples/serverless-coffee/issues/16)

## Motivation and Context
Remove some friction from getting started

## How Has This Been Tested?
I ran the updated commands to install

## Screenshots (if appropriate):
N/A